### PR TITLE
feat: add create project page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "axios": "^1.7.7",
+        "bootstrap-icons": "^1.11.3",
         "clsx": "^2.1.1",
         "cookies-next": "^4.3.0",
         "ms": "^2.1.3",
@@ -1573,6 +1574,22 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.11.3.tgz",
+      "integrity": "sha512-+3lpHrCw/it2/7lBL15VR0HEumaBss0+f/Lb6ZvHISn1mlK83jjFpooTLsMWbIjJMDjDjOExMsTxnXSIT4k4ww==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "axios": "^1.7.7",
+    "bootstrap-icons": "^1.11.3",
     "clsx": "^2.1.1",
     "cookies-next": "^4.3.0",
     "ms": "^2.1.3",

--- a/src/app/(app)/adauga-proiect/page.tsx
+++ b/src/app/(app)/adauga-proiect/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 import Button from '@/app/components/Button'
 import Input from '@/app/components/Input'
+import RadioInputs from '@/app/components/RadioInputs'
 import useSubmitForm from '@/utils/useSubmitForm'
 import 'bootstrap-icons/font/bootstrap-icons.css'
 
@@ -58,6 +59,14 @@ export default function AddProjectPage() {
                 type="textarea"
                 name="description"
                 error={fieldErrors.description}></Input>
+            <RadioInputs
+                label="Activ (vizibul la public)?"
+                name="active"
+                options={[
+                    { value: true, label: 'Da' },
+                    { value: false, label: 'Nu' },
+                ]}
+                error={fieldErrors.active}></RadioInputs>
 
             <Button loading={loading} label="Salveaza"></Button>
             {error && <p className="text-red-700 mt-4">Eroare: {error}</p>}

--- a/src/app/(app)/adauga-proiect/page.tsx
+++ b/src/app/(app)/adauga-proiect/page.tsx
@@ -4,12 +4,18 @@ import Input from '@/app/components/Input'
 import RadioInputs from '@/app/components/RadioInputs'
 import useSubmitForm from '@/utils/useSubmitForm'
 import 'bootstrap-icons/font/bootstrap-icons.css'
+import { useRouter } from 'next/navigation'
 import { SyntheticEvent, useState } from 'react'
 
 export default function AddProjectPage() {
+    const router = useRouter()
+    const onSuccess = () => {
+        router.push('/proiecte')
+    }
+
     const { error, fieldErrors, handleOnSubmit, loading } = useSubmitForm(
         '/projects',
-        () => {}
+        onSuccess
     )
 
     const [photos, setPhotos] = useState<string[]>([])

--- a/src/app/(app)/adauga-proiect/page.tsx
+++ b/src/app/(app)/adauga-proiect/page.tsx
@@ -4,6 +4,7 @@ import Input from '@/app/components/Input'
 import RadioInputs from '@/app/components/RadioInputs'
 import useSubmitForm from '@/utils/useSubmitForm'
 import 'bootstrap-icons/font/bootstrap-icons.css'
+import { SyntheticEvent, useState } from 'react'
 
 export default function AddProjectPage() {
     const { error, fieldErrors, handleOnSubmit, loading } = useSubmitForm(
@@ -11,13 +12,28 @@ export default function AddProjectPage() {
         () => {}
     )
 
-    const photos = [
-        'https://placehold.co/250x200.png',
-        'https://placehold.co/250x400.png',
-        'https://placehold.co/250.png',
-        'https://placehold.co/250.png',
-        'https://placehold.co/250.png',
-    ]
+    const [photos, setPhotos] = useState<string[]>([])
+
+    const handleFiles = (event: SyntheticEvent<HTMLInputElement>) => {
+        console.log(event.currentTarget.files)
+
+        for (const file of event.currentTarget.files || []) {
+            const fileReader = new FileReader()
+
+            fileReader.addEventListener(
+                'load',
+                () => {
+                    setPhotos(photos => [
+                        ...photos,
+                        fileReader.result as string,
+                    ])
+                },
+                false
+            )
+
+            fileReader.readAsDataURL(file)
+        }
+    }
 
     return (
         <form onSubmit={handleOnSubmit}>
@@ -25,23 +41,21 @@ export default function AddProjectPage() {
 
             <p className="text-sm mb-1 font-bold">Imagini</p>
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2 mb-4">
-                {photos.map(photo => (
+                {photos.map((photo, photoIndex) => (
                     <div
                         className="w-full aspect-square bg-no-repeat bg-center bg-cover p-1 text-right"
                         style={{ backgroundImage: `url('${photo}')` }}
-                        key={photo}>
-                        <a className="p-1 hover:bg-gray-100 cursor-pointer transition-all">
-                            <i className="bi-x text-lg"></i>
-                        </a>
-                    </div>
+                        key={photoIndex}></div>
                 ))}
 
                 <label className="w-full aspect-square gap-2 p-2 flex justify-center items-center flex-col border-[1px] border-dashed border-blue-300 hover:bg-blue-50 cursor-pointer text-center">
                     <input
                         type="file"
+                        name="photos"
                         className="hidden"
                         accept="image/*"
                         multiple
+                        onChange={handleFiles}
                     />
 
                     <i className="bi-upload text-xl"></i>

--- a/src/app/(app)/adauga-proiect/page.tsx
+++ b/src/app/(app)/adauga-proiect/page.tsx
@@ -66,6 +66,7 @@ export default function AddProjectPage() {
                     { value: true, label: 'Da' },
                     { value: false, label: 'Nu' },
                 ]}
+                defaultValue={true}
                 error={fieldErrors.active}></RadioInputs>
 
             <Button loading={loading} label="Salveaza"></Button>

--- a/src/app/(app)/adauga-proiect/page.tsx
+++ b/src/app/(app)/adauga-proiect/page.tsx
@@ -1,0 +1,66 @@
+'use client'
+import Button from '@/app/components/Button'
+import Input from '@/app/components/Input'
+import useSubmitForm from '@/utils/useSubmitForm'
+import 'bootstrap-icons/font/bootstrap-icons.css'
+
+export default function AddProjectPage() {
+    const { error, fieldErrors, handleOnSubmit, loading } = useSubmitForm(
+        '/projects',
+        () => {}
+    )
+
+    const photos = [
+        'https://placehold.co/250x200.png',
+        'https://placehold.co/250x400.png',
+        'https://placehold.co/250.png',
+        'https://placehold.co/250.png',
+        'https://placehold.co/250.png',
+    ]
+
+    return (
+        <form onSubmit={handleOnSubmit}>
+            <h1 className="text-2xl font-bold mb-6">Adauga proiect</h1>
+
+            <p className="text-sm mb-1 font-bold">Imagini</p>
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-2 mb-4">
+                {photos.map(photo => (
+                    <div
+                        className="w-full aspect-square bg-no-repeat bg-center bg-cover p-1 text-right"
+                        style={{ backgroundImage: `url('${photo}')` }}
+                        key={photo}>
+                        <a className="p-1 hover:bg-gray-100 cursor-pointer transition-all">
+                            <i className="bi-x text-lg"></i>
+                        </a>
+                    </div>
+                ))}
+
+                <label className="w-full aspect-square gap-2 p-2 flex justify-center items-center flex-col border-[1px] border-dashed border-blue-300 hover:bg-blue-50 cursor-pointer text-center">
+                    <input
+                        type="file"
+                        className="hidden"
+                        accept="image/*"
+                        multiple
+                    />
+
+                    <i className="bi-upload text-xl"></i>
+                    <p className="text-sm">Incarca</p>
+                </label>
+            </div>
+
+            <Input
+                label="Denumire"
+                name="name"
+                error={fieldErrors.name}></Input>
+            <Input label="Link" name="url" error={fieldErrors.url}></Input>
+            <Input
+                label="Descriere"
+                type="textarea"
+                name="description"
+                error={fieldErrors.description}></Input>
+
+            <Button loading={loading} label="Salveaza"></Button>
+            {error && <p className="text-red-700 mt-4">Eroare: {error}</p>}
+        </form>
+    )
+}

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react'
+
+export default function AppLayout({ children }: { children: ReactNode }) {
+    return (
+        <div className="px-4 py-8 w-full sm:w-4/5 md:w-3/5 lg:w-2/5 mx-auto">
+            {children}
+        </div>
+    )
+}

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx'
 import { FormEvent } from 'react'
+import InputError from './InputError'
 
 interface InputProps {
     label: string
@@ -51,7 +52,8 @@ export default function Input({
                     <input {...inputProps} type={type} />
                 )}
             </label>
-            {error && <p className="text-red-700 text-sm mt-1">{error}</p>}
+
+            <InputError message={error}></InputError>
         </div>
     )
 }

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx'
+import { FormEvent } from 'react'
 
 interface InputProps {
     label: string
@@ -6,7 +7,7 @@ interface InputProps {
     value?: string
     name?: string
     disabled?: boolean
-    type?: 'text' | 'email' | 'password'
+    type?: 'text' | 'email' | 'password' | 'textarea'
     setValue?: (newValue: string) => any
 }
 
@@ -19,6 +20,18 @@ export default function Input({
     disabled = false,
     type = 'text',
 }: InputProps) {
+    const inputProps = {
+        className: clsx(
+            'block w-full outline-none border-[1px] border-blue-300 focus:border-blue-400 px-4 py-1 rounded-sm',
+            { 'border-red-500 focus:border-red-700': !!error }
+        ),
+        value: value,
+        onChange: (event: FormEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+            setValue ? setValue(event.currentTarget.value) : null,
+        disabled: disabled,
+        name: name,
+    }
+
     return (
         <div
             className={clsx('mb-4', {
@@ -31,21 +44,12 @@ export default function Input({
                     })}>
                     {label}
                 </span>
-                <input
-                    className={clsx(
-                        'block w-full outline-none border-[1px] border-blue-300 focus:border-blue-400 px-4 py-1 rounded-sm',
-                        {
-                            'border-red-500 focus:border-red-700': !!error,
-                        }
-                    )}
-                    type={type}
-                    value={value}
-                    onChange={event =>
-                        setValue ? setValue(event.target.value) : null
-                    }
-                    disabled={disabled}
-                    name={name}
-                />
+
+                {type === 'textarea' ? (
+                    <textarea {...inputProps}></textarea>
+                ) : (
+                    <input {...inputProps} type={type} />
+                )}
             </label>
             {error && <p className="text-red-700 text-sm mt-1">{error}</p>}
         </div>

--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -1,3 +1,4 @@
+import { useInputClassNames } from '@/utils/useInputClassNames'
 import clsx from 'clsx'
 import { FormEvent } from 'react'
 import InputError from './InputError'
@@ -33,18 +34,15 @@ export default function Input({
         name: name,
     }
 
+    const { labelClassName } = useInputClassNames(error)
+
     return (
         <div
             className={clsx('mb-4', {
                 'opacity-70': disabled,
             })}>
             <label>
-                <span
-                    className={clsx('block text-sm mb-1 font-bold', {
-                        'text-red-700': !!error,
-                    })}>
-                    {label}
-                </span>
+                <span className={labelClassName}>{label}</span>
 
                 {type === 'textarea' ? (
                     <textarea {...inputProps}></textarea>

--- a/src/app/components/InputError.tsx
+++ b/src/app/components/InputError.tsx
@@ -1,0 +1,8 @@
+interface Props {
+    message: string | null
+}
+
+export default function InputError({ message }: Props) {
+    if (!message) return
+    return <p className="text-red-700 text-sm mt-1">{message}</p>
+}

--- a/src/app/components/RadioInputs.tsx
+++ b/src/app/components/RadioInputs.tsx
@@ -31,12 +31,13 @@ export default function RadioInputs<T>({
             </label>
 
             {options.map(option => (
-                <label className="block mb-1">
+                <label className="block mb-1" key={option.label}>
                     {/* the lack of the "name" attribute is intentional here as it won't be sent with the http requests */}
                     <input
                         type="radio"
                         onClick={() => setSelectedValue(option.value)}
                         checked={selectedValue === option.value}
+                        onChange={() => {}}
                         className="mr-2"
                     />
                     <span>{option.label}</span>

--- a/src/app/components/RadioInputs.tsx
+++ b/src/app/components/RadioInputs.tsx
@@ -3,15 +3,22 @@ import { useState } from 'react'
 import InputError from './InputError'
 import { useInputClassNames } from '@/utils/useInputClassNames'
 
-interface Props {
+interface Props<T> {
     label: string
     name?: string
     error: string | null
-    options: { value: any; label: string }[]
+    options: { value: T; label: string }[]
+    defaultValue?: T
 }
 
-export default function RadioInputs({ label, name, error, options }: Props) {
-    const [selectedValue, setSelectedValue] = useState(undefined)
+export default function RadioInputs<T>({
+    label,
+    name,
+    error,
+    options,
+    defaultValue,
+}: Props<T>) {
+    const [selectedValue, setSelectedValue] = useState(defaultValue)
 
     const { labelClassName } = useInputClassNames(error)
 

--- a/src/app/components/RadioInputs.tsx
+++ b/src/app/components/RadioInputs.tsx
@@ -1,0 +1,42 @@
+'use client'
+import { useState } from 'react'
+import InputError from './InputError'
+import { useInputClassNames } from '@/utils/useInputClassNames'
+
+interface Props {
+    label: string
+    name?: string
+    error: string | null
+    options: { value: any; label: string }[]
+}
+
+export default function RadioInputs({ label, name, error, options }: Props) {
+    const [selectedValue, setSelectedValue] = useState(undefined)
+
+    const { labelClassName } = useInputClassNames(error)
+
+    return (
+        <div className="mb-4">
+            <label className={labelClassName}>
+                {label}
+                {/* this input is hidden, but because it has a name attribute, so it will be sent with http requests */}
+                <input type="hidden" name={name} value={selectedValue} />
+            </label>
+
+            {options.map(option => (
+                <label className="block mb-1">
+                    {/* the lack of the "name" attribute is intentional here as it won't be sent with the http requests */}
+                    <input
+                        type="radio"
+                        onClick={() => setSelectedValue(option.value)}
+                        checked={selectedValue === option.value}
+                        className="mr-2"
+                    />
+                    <span>{option.label}</span>
+                </label>
+            ))}
+
+            <InputError message={error}></InputError>
+        </div>
+    )
+}

--- a/src/utils/getFormData.ts
+++ b/src/utils/getFormData.ts
@@ -1,8 +1,35 @@
 import { SyntheticEvent } from 'react'
 
 export default function getFormData(event: SyntheticEvent<HTMLFormElement>) {
-    const formData = new FormData(event.target)
-    const formDataEntries = formData.entries()
-    const formDataObject = Object.fromEntries(formDataEntries)
-    return formDataObject
+    const formData = new FormData(event.target as HTMLFormElement)
+    const formDataObject: {
+        [key: string]: FormDataEntryValue | FormDataEntryValue[]
+    } = {}
+
+    let hasFiles = false
+
+    formData.forEach((value, key) => {
+        if (value instanceof File) hasFiles = true
+
+        if (!formDataObject[key]) {
+            formDataObject[key] = value
+            return
+        }
+
+        // The inputs that accept multiple file will appear multiple times.
+        // They need to be merged into a single array
+        if (!Array.isArray(formDataObject[key])) {
+            formDataObject[key] = [formDataObject[key]]
+        }
+        ;(formDataObject[key] as FormDataEntryValue[]).push(value)
+    })
+
+    const headers = {
+        'content-type': hasFiles ? 'multipart/form-data' : 'application/json',
+    }
+
+    return {
+        data: formDataObject,
+        headers,
+    }
 }

--- a/src/utils/useInputClassNames.ts
+++ b/src/utils/useInputClassNames.ts
@@ -1,0 +1,18 @@
+import clsx from 'clsx'
+import { useEffect, useState } from 'react'
+
+export const useInputClassNames = (error?: string | null) => {
+    const [labelClassName, setLabelClassName] = useState('')
+
+    useEffect(() => {
+        setLabelClassName(
+            clsx('block text-sm mb-1 font-bold', {
+                'text-red-700': !!error,
+            })
+        )
+    }, [error])
+
+    return {
+        labelClassName,
+    }
+}

--- a/src/utils/useSubmitForm.ts
+++ b/src/utils/useSubmitForm.ts
@@ -1,5 +1,6 @@
 import getFormData from '@/utils/getFormData'
 import axios, { AxiosError } from 'axios'
+import { useRouter } from 'next/navigation'
 import { SyntheticEvent, useState } from 'react'
 
 export default function useSubmitForm(
@@ -9,6 +10,7 @@ export default function useSubmitForm(
     const [fieldErrors, setFieldErrors] = useState({})
     const [error, setError] = useState<string | null>(null)
     const [loading, setLoading] = useState(false)
+    const router = useRouter()
 
     async function handleOnSubmit(event: SyntheticEvent<HTMLFormElement>) {
         event.preventDefault()
@@ -49,6 +51,15 @@ export default function useSubmitForm(
                         }))
                     }
                 }
+                return
+            }
+
+            if (apiError.response.status === 401) {
+                const currentPage = location.pathname + location.search
+                router.push(
+                    `/autentificare?next=${currentPage}&error=${apiError.response.data.message}`
+                )
+                return
             }
         } finally {
             setLoading(false)

--- a/src/utils/useSubmitForm.ts
+++ b/src/utils/useSubmitForm.ts
@@ -15,11 +15,13 @@ export default function useSubmitForm(
         setLoading(true)
         setFieldErrors({})
         setError(null)
-        const formData = getFormData(event)
+        const { data: formData, headers } = getFormData(event)
 
         try {
             const { data } = await axios.post(url, formData, {
                 baseURL: process.env.NEXT_PUBLIC_SERVER_URL,
+                formSerializer: { indexes: null },
+                headers,
             })
             await handleSuccess(data)
         } catch (apiError) {


### PR DESCRIPTION
- feat: make the input component accept type textarea
- feat: add layout for the app/logged in pages
- feat: add create project page - not functional
- refactor: extract the error message from the input field to a component for reusability
- refactor: extract the class names of the input label to a hook for reusability
- feat: add radio input component
- feat: add the 'active' input to the add project page
- feat: make the useSubmitForm accept file inputs
- feat: add default value to RadioInputs
- feat: make the photo preview feature functional
- feat: redirect to login page on 401 responses
- feat: redirect to admin page after creating a project
- fix: fix react errors about missing key and readonly inputs
